### PR TITLE
Fix plugin card fields and API path

### DIFF
--- a/app/components/PluginCard.tsx
+++ b/app/components/PluginCard.tsx
@@ -11,7 +11,7 @@ export default function PluginCard({ plugin }: { plugin: any }) {
 
   return (
     <div className="border p-4 rounded w-full max-w-md">
-      <h3 className="text-lg font-semibold">{plugin.name}</h3>
+      <h3 className="text-lg font-semibold">{plugin.title}</h3>
       <div
         className="text-sm text-gray-600"
         dangerouslySetInnerHTML={{ __html: safeHtml }}
@@ -25,9 +25,9 @@ export default function PluginCard({ plugin }: { plugin: any }) {
         })}
       </p>
 
-      {plugin.file && (
+      {plugin.fileUrl && (
         <a
-          href={plugin.file}
+          href={plugin.fileUrl}
           download
           className="inline-block mt-2 bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-500 text-sm"
         >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,11 @@ export default function HomePage() {
   const [stats, setStats] = useState({ plugins: 0, users: 0, downloads: 0 });
 
   useEffect(() => {
-    async function fetchPlugins() {
-      const res = await fetch("/api/plugins/latest");
-      const data = await res.json();
-      setPlugins(data);
-    }
+      async function fetchPlugins() {
+        const res = await fetch("/api/plugin/latest");
+        const data = await res.json();
+        setPlugins(data);
+      }
 
     async function fetchStats() {
       const res = await fetch("/api/stats");


### PR DESCRIPTION
## Summary
- fix download link and title rendering in `PluginCard`
- use correct endpoint `/api/plugin/latest` on HomePage

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686afbd8abf0832ebf996076d8d1688f