### PR TITLE
Fix EditPluginPage param typing

### DIFF
--- a/app/profile/edit/[id]/page.tsx
+++ b/app/profile/edit/[id]/page.tsx
@@ -1,13 +1,10 @@
 import { prisma } from '@/lib/prisma'; // Passe den Pfad an dein Setup an
 import EditForm from './EditForm';
+import type { PageProps } from 'next';
 
-interface Props {
-  params: {
-    id: string;
-  };
-}
-
-export default async function EditPluginPage({ params }: Props) {
+export default async function EditPluginPage({
+  params,
+}: PageProps<{ id: string }>) {
   const pluginId = Number(params.id);
   const plugin = await prisma.plugin.findUnique({
     where: { id: pluginId },


### PR DESCRIPTION
## Summary
- use Next.js `PageProps` for dynamic route params in EditPluginPage

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afe32a0b8832eaebc4b80840bddc3