### PR TITLE
Fix compile error by replacing PageProps import

### DIFF
--- a/app/profile/edit/[id]/page.tsx
+++ b/app/profile/edit/[id]/page.tsx
@@ -1,10 +1,10 @@
 import { prisma } from '@/lib/prisma'; // Passe den Pfad an dein Setup an
 import EditForm from './EditForm';
-import type { PageProps } from 'next';
+interface PageProps {
+  params: { id: string };
+}
 
-export default async function EditPluginPage({
-  params,
-}: PageProps<{ id: string }>) {
+export default async function EditPluginPage({ params }: PageProps) {
   const pluginId = Number(params.id);
   const plugin = await prisma.plugin.findUnique({
     where: { id: pluginId },


### PR DESCRIPTION
## Summary
- remove deprecated PageProps import from Next.js page
- create custom interface for route params

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686aff39a600832eb1d8f3fb361cbbba